### PR TITLE
Fixes for nuisance impacts etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 1. Follow the `combine` instructions: https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/#setting-up-the-environment-and-installation .
 Current results are using release `CMSSW_11_3_4`, tag v9.1.0.
+Make sure to install `CombineHarvester` as well (bottom of that page).
 
 2. Clone this repository:
 
@@ -66,6 +67,15 @@ Fit the toys:
 python cli_boosted.py fittoys dc_Jun08/dc_mz350_rinv0.3_bdt0p300.txt --toysFile toys_Jul25/higgsCombineObserveddc_mz350_rinv0.3_bdt0p300.GenerateOnly.mH120.1001.root --expectSignal 0
 ```
 
+## Nuisance impacts
+
+The nuisance impacts show how much each systematic uncertainty impacts the fit, and whether any systematics are pulled or constrained.
+The input is a datacard txt file.
+Signal injection is required to see the effects of signal systematics (the uncertainty variations are checked at the likelihood minimum, which is `r=0` without signal injection).
+
+```bash
+python3 cli_boosted.py impacts dc.txt --nfits 16 --asimov --normRange 0.1 2.0 --rMin -10 --rMax 10 --robustFit 1 --expectSignal 0.2
+```
 
 ## Plotting
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You first need a `histograms.json` file; see https://github.com/boostedsvj/svj_u
 Then:
 
 ```bash
-python cli_boosted.py gen_datacards_mp histograms_Mar14.json
+python cli_boosted.py gen_datacards_v2 histograms_Mar14.json
 ```
 
 

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -1918,7 +1918,7 @@ class CombineCommand(object):
             if expectSignal is not None: self.kwargs['--expectSignal'] = expectSignal
 
             # Pass-through: Anything that's left is simply tagged on to the combine command as is
-            self.raw = ' '.join(sys.argv)
+            self.pass_through = ' '.join(sys.argv[1:])
 
 
     def parse(self):
@@ -1945,7 +1945,7 @@ class CombineCommand(object):
             strs = ['{0}={1},{2}'.format(parname, *ranges) for parname, ranges in self.parameter_ranges.items()]
             command.append('--setParameterRanges ' + ':'.join(strs))
 
-        if self.pass_through: command.append(' '.join(self.pass_through))
+        if self.pass_through: command.append(self.pass_through)
 
         return command
 

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -488,6 +488,8 @@ def impacts():
     dc = bsvj.Datacard.from_txt(osp.abspath(dc_file))
     base_cmd = bsvj.CombineCommand(dc)
     base_cmd.configure_from_command_line()
+    if '--toysFrequentist' in base_cmd.args:
+        base_cmd.args.remove('--toysFrequentist')
 
     workdir = strftime(f'impacts_cli_%Y%m%d_{osp.basename(dc_file).replace(".txt","")}')
     bsvj.logger.info(f'Executing from {workdir}')
@@ -530,8 +532,6 @@ def impacts():
     combinetool_dofit_cmd.named.update(systs)
     combinetool_dofit_cmd.kwargs['--redefineSignalPOIs'] = 'r'
     combinetool_dofit_cmd.name = 'Test'
-    if '--toysFrequentist' in combinetool_dofit_cmd.args:
-        combinetool_dofit_cmd.args.remove('--toysFrequentist')
     bsvj.run_combine_command(combinetool_dofit_cmd, logfile=cmd.logfile)
 
     # combine all impacts

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -13,6 +13,7 @@ import boosted_fits as bsvj
 
 import ROOT # type: ignore
 ROOT.RooMsgService.instance().setSilentMode(True)
+ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.ERROR)
 
 scripter = bsvj.Scripter()
 

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -482,6 +482,7 @@ def fittoys():
 
 @scripter
 def impacts(dc_file=None):
+    norm = bsvj.pull_arg('--norm', type=float, nargs=2, default=[0.1,2.0]).norm
     nfits = bsvj.pull_arg('--nfits', type=int, default=1).nfits
     expectSignal = bsvj.pull_arg('--expectSignal', type=float, default=0.2).expectSignal
     if dc_file is None:
@@ -521,7 +522,7 @@ def impacts(dc_file=None):
     cmd.kwargs['-t'] = -1
     cmd.kwargs['--expectSignal'] = expectSignal
     cmd.args.add('--saveWorkspace')
-    cmd.add_range('shapeBkg_roomultipdf_bsvj__norm', 0.1, 2.0)
+    cmd.add_range('shapeBkg_roomultipdf_bsvj__norm', norm[0], norm[1])
     cmd.name = '_initialFit_Test'
     if osp.isfile(cmd.outfile):
         bsvj.logger.warning(

--- a/quick_plot.py
+++ b/quick_plot.py
@@ -3,11 +3,13 @@ Some scripts to quickly plot basic outcomes from combine scans
 """
 from __future__ import print_function
 import ROOT # type:ignore
+ROOT.RooMsgService.instance().setSilentMode(True)
+ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.ERROR)
 from time import strftime
 import argparse
 
 # Add the directory of this file to the path so the boosted tools can be imported
-import sys, os, os.path as osp, pprint, re, traceback, copy, fnmatch
+import sys, os, os.path as osp, pprint, re, traceback, copy, fnmatch, shutil
 from contextlib import contextmanager
 sys.path.append(osp.dirname(osp.abspath(__file__)))
 import boosted_fits as bsvj
@@ -33,12 +35,10 @@ cms_green = '#74f94c'
 scripter = bsvj.Scripter()
 
 def cmd_exists(executable):
-    """
-    Checks if a command can be found on the system path.
-    Not a very smart implementation but does the job usually.
-    See https://stackoverflow.com/a/28909933/9209944 .
-    """
-    return any(os.access(os.path.join(path, executable), os.X_OK) for path in os.environ["PATH"].split(os.pathsep))
+    if shutil.which(executable):
+        return True
+    else:
+        return False
 
 BATCH_MODE = False
 def batch_mode(flag=True):


### PR DESCRIPTION
This PR implements various fixes and improvements:
* Nuisance impacts take initial fit as input
* Filter impact output json to remove background systematics, instead of rerunning CombineHarvester
* Run impacts for a given signal in parallel (builtin CombineHarvester functionality), instead of running multiple signals in parallel manually
* Some better histogram functions from svj_uboost
* Fix passthrough args for Combine
* Allow using CombineHarvester commands in CombineCommand
* Actually silence most RooFit messages