### PR TITLE
Clean up PDF code and add more functions

### DIFF
--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -334,7 +334,7 @@ def get_jsons():
 # all_pdfs can have more values than in this list
 # this list controls what actually runs
 def known_pdfs():
-    pdf_list = ["main", "alt", "ua2", "ua2mod"]
+    pdf_list = ["main", "alt", "ua2"]
     return pdf_list
 
 def make_pdf(name, mt, bkg_th1):

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -853,13 +853,13 @@ def pdf_expression(pdf_type, npars, mt_scale='1000'):
 
     elif pdf_type == 'ua2':
         if npars == 2:
-            expression = 'pow(@0/{0}, @1) * exp(@1*@2*(@0/{0}))'
+            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2))'
         if npars == 3:
-            expression = 'pow(@0/{0}, @1) * exp(@1*@0/{0}*(1 + @2+ @3*@0/{0}))' #fifth variation
+            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0}))' #fifth variation
         if npars == 4:
-            expression = 'pow(@0/{0}, @1) * exp(@1*@0/{0}*(1 + @2+ @3*@0/{0} + @4*pow(@0/{0},2)))' #fifth variation            
+            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0} + @4*pow(@0/{0},2)))' #fifth variation            
         if npars == 5:
-            expression = 'pow(@0/{0}, @1) * exp(@1*@0/{0}*(1 + @2+ @3*@0/{0} + @4*pow(@0/{0},2) + @5*pow(@0/{0},3)))' #fifth variation
+            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0} + @4*pow(@0/{0},2) + @5*pow(@0/{0},3)))' #fifth variation
 
     else:
         raise Exception('Unknown pdf type {0}'.format(pdf_type))

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -332,7 +332,7 @@ def get_jsons():
     return result
 
 def known_pdfs():
-    pdf_list = ["main", "alt", "ua2"]
+    pdf_list = ["main", "alt", "ua2", "modexp", "polpow"]
     return pdf_list
 
 def make_pdf(name, mt, bkg_th1):
@@ -857,12 +857,36 @@ def pdf_expression(pdf_type, npars, mt_scale='1000'):
     elif pdf_type == 'ua2':
         if npars == 2:
             expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2))'
-        if npars == 3:
-            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0}))' #fifth variation
-        if npars == 4:
-            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0} + @4*pow(@0/{0},2)))' #fifth variation            
-        if npars == 5:
-            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0} + @4*pow(@0/{0},2) + @5*pow(@0/{0},3)))' #fifth variation
+        elif npars == 3:
+            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0}))'
+        elif npars == 4:
+            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0} + @4*pow(@0/{0},2)))'
+        elif npars == 5:
+            expression = 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0} + @4*pow(@0/{0},2) + @5*pow(@0/{0},3)))'
+        else:
+            raise Exception('Unavailable npars for main: {0}'.format(npars))
+
+    elif pdf_type == 'modexp':
+        if npars == 2:
+            expression = 'exp(@1*pow(@0/{0}, @2))'
+        elif npars == 3:
+            expression = 'exp(@1*pow(@0/{0}, @2)+@1*pow(@0/{0}, @3))'
+        elif npars == 4:
+            expression = 'exp(@1*pow(@0/{0}, @2)+@4*pow(@0/{0}, @3))'
+        else:
+            raise Exception('Unavailable npars for modexp: {0}'.format(npars))
+
+    elif pdf_type == 'polpow':
+        if npars == 2:
+            expression = 'pow(1 + @1*@0/{0},-@2)'
+        elif npars == 3:
+            expression = 'pow(1 + @1*@0/{0} + @2*pow(@0/{0},2),-@3)'
+        elif npars == 4:
+            expression = 'pow(1 + @1*@0/{0} + @2*pow(@0/{0},2) + @3*pow(@0/{0},3),-@4)'
+        elif npars == 5:
+            expression = 'pow(1 + @1*@0/{0} + @2*pow(@0/{0},2) + @3*pow(@0/{0},3) + @4*pow(@0/{0},4),-@5)'
+        else:
+            raise Exception('Unavailable npars for polpow: {0}'.format(npars))
 
     else:
         raise Exception('Unknown pdf type {0}'.format(pdf_type))
@@ -925,7 +949,6 @@ def pdf_parameters(pdf_type, npars, prefix=None):
                 ROOT.RooRealVar(prefix + "_p1", "p1", 1., -100., 100.),
                 ROOT.RooRealVar(prefix + "_p2", "p2", 1., -100., 100.)
                 ]
-
         elif npars == 3:
             parameters = [
                 ROOT.RooRealVar(prefix + "_p1", "p1", 1., -100., 100.),
@@ -947,6 +970,55 @@ def pdf_parameters(pdf_type, npars, prefix=None):
                 ROOT.RooRealVar(prefix + "_p4", "p4", 1., -100., 100.),
                 ROOT.RooRealVar(prefix + "_p5", "p5", 1., -100., 100.),
                 ]
+
+    elif pdf_type == 'modexp':
+        if npars == 2:
+            parameters = [
+                ROOT.RooRealVar(prefix + "_p1", "p1", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p2", "p2", 1., -100., 100.)
+                ]
+        elif npars == 3:
+            parameters = [
+                ROOT.RooRealVar(prefix + "_p1", "p1", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p2", "p2", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p3", "p3", 1., -100., 100),
+                ]
+        elif npars == 4:
+            parameters = [
+                ROOT.RooRealVar(prefix + "_p1", "p1", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p2", "p2", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p3", "p3", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p4", "p4", 1., -100., 100.),
+                ]
+
+    elif pdf_type == 'polpow':
+        if npars == 2:
+            parameters = [
+                ROOT.RooRealVar(prefix + "_p1", "p1", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p2", "p2", 1., -100., 100.)
+                ]
+        elif npars == 3:
+            parameters = [
+                ROOT.RooRealVar(prefix + "_p1", "p1", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p2", "p2", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p3", "p3", 1., -100., 100),
+                ]
+        elif npars == 4:
+            parameters = [
+                ROOT.RooRealVar(prefix + "_p1", "p1", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p2", "p2", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p3", "p3", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p4", "p4", 1., -100., 100.),
+                ]
+        elif npars == 5:
+            parameters = [
+                ROOT.RooRealVar(prefix + "_p1", "p1", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p2", "p2", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p3", "p3", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p4", "p4", 1., -100., 100.),
+                ROOT.RooRealVar(prefix + "_p5", "p5", 1., -100., 100.),
+                ]
+
     object_keeper.add_multiple(parameters)
     return parameters
 
@@ -1042,7 +1114,7 @@ def pdfs_factory(pdf_type, mt, bkg_th1, name=None, mt_scale='1000', trigeff=None
     Like pdf_factory, but returns a list for all available n_pars
     """
     if name is None: name = uid()
-    all_n_pars = [2, 3, 4] if pdf_type == 'alt' else [2, 3, 4, 5]
+    all_n_pars = [2, 3, 4] if pdf_type == 'alt' or pdf_type == 'modexp' else [2, 3, 4, 5]
     if npars is not None: all_n_pars = [npars]
     return [ pdf_factory(pdf_type, n_pars, mt, bkg_th1, name+'_npars'+str(n_pars), mt_scale, trigeff=trigeff) for n_pars in all_n_pars]
 

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -334,7 +334,7 @@ def get_jsons():
 # all_pdfs can have more values than in this list
 # this list controls what actually runs
 def known_pdfs():
-    pdf_list = ["main", "alt", "ua2"]
+    pdf_list = ["main", "alt", "ua2", "ua2mod"]
     return pdf_list
 
 def make_pdf(name, mt, bkg_th1):
@@ -415,6 +415,23 @@ all_pdfs = {
         },
         5: {
             "expr": 'pow(@0/{0}, @1) * exp(@0/{0}*(@2+ @3*@0/{0} + @4*pow(@0/{0},2) + @5*pow(@0/{0},3)))',
+        },
+    }),
+    "ua2mod": PdfInfo("ua2mod", {
+        1: {
+            "expr": 'exp(@1*@0/{0})',
+        },
+        2: {
+            "expr": 'exp(@1*@0/{0} + @2*pow(@0/{0},2))',
+        },
+        3: {
+            "expr": 'exp(@1*@0/{0} + @2*pow(@0/{0},2) + @3*pow(@0/{0},3))',
+        },
+        4: {
+            "expr": 'exp(@1*@0/{0} + @2*pow(@0/{0},2) + @3*pow(@0/{0},3) + @4*pow(@0/{0},4))',
+        },
+        5: {
+            "expr": 'exp(@1*@0/{0} + @2*pow(@0/{0},2) + @3*pow(@0/{0},3) + @4*pow(@0/{0},4) + @5*pow(@0/{0},5))',
         },
     }),
     "modexp": PdfInfo("modexp", {

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -335,7 +335,6 @@ def fittoys():
         cmd.kwargs['--X-rtd'] = 'MINIMIZER_MaxCalls=100000'
 
         toysFile = bsvj.pull_arg('--toysFile', required=True, type=str).toysFile
-        #cmd.kwargs['--toysFile'] = toysFile
 
         if not '-t' in cmd.kwargs:
             with bsvj.open_root(toysFile) as f:

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -25,7 +25,7 @@ def plot_scipy_fits():
     parser.add_argument('-o', '--plotdir', type=str, default='plots_bkgfits_%b%d')
     parser.add_argument('-b', '--bdtcut', type=float, default=None)
     parser.add_argument('-n', '--npars', type=int, nargs='*')
-    parser.add_argument('-p', '--pdftype', type=str, default=None, choices=['main', 'ua2'])
+    parser.add_argument('-p', '--pdftype', type=str, default=None, choices=bsvj.known_pdfs())
 
     args = parser.parse_args()
     plotdir = strftime(args.plotdir)
@@ -40,7 +40,7 @@ def plot_scipy_fits():
             tdir = tf.Get(tdir_name)
             bkg_hist = tdir.Get('Bkg')
 
-            for pdf_type in ['main', 'alt', 'ua2']:
+            for pdf_type in bsvj.known_pdfs():
                 if args.pdftype and pdf_type != args.pdftype: continue
                 bsvj.logger.info('Fitting pdf_type=%s, tdir_name=%s', pdf_type, tdir_name)
                 fig = plt.figure(figsize=(8,8))
@@ -87,7 +87,7 @@ def plot_roofit_fits():
     parser.add_argument('-o', '--plotdir', type=str, default='plots_bkgfits_%b%d')
     parser.add_argument('-b', '--bdtcut', type=float, default=None)
     parser.add_argument('-n', '--npars', type=int, nargs='*')
-    parser.add_argument('-p', '--pdftype', type=str, default=None, choices=['main', 'alt', 'ua2'])
+    parser.add_argument('-p', '--pdftype', type=str, default=None, choices=bsvj.known_pdfs())
     args = parser.parse_args()
     plotdir = strftime(args.plotdir)
     if not osp.isdir(plotdir): os.makedirs(plotdir)
@@ -98,7 +98,7 @@ def plot_roofit_fits():
             tdir = tf.Get(tdir_name)
             bkg_hist = tdir.Get('Bkg')
             mt = bsvj.get_mt_from_th1(bkg_hist)
-            for pdf_type in ['main', 'alt', 'ua2']:
+            for pdf_type in bsvj.known_pdfs():
                 if args.pdftype and pdf_type != args.pdftype: continue
                 bsvj.logger.info('Fitting pdf_type=%s, tdir_name=%s', pdf_type, tdir_name)
                 if args.npars is not None and len(args.npars):

--- a/quick_plot.py
+++ b/quick_plot.py
@@ -775,7 +775,7 @@ def bkgfit():
     Bkg fit plots
     """
     jsons = bsvj.get_jsons()
-    pdftype = bsvj.pull_arg('pdftype', type=str, choices=['main', 'alt', 'ua2']).pdftype
+    pdftype = bsvj.pull_arg('pdftype', type=str, choices=bsvj.known_pdfs()).pdftype
     linscale = bsvj.pull_arg('--lin', action='store_true').lin
     scipyonly = bsvj.pull_arg('--scipyonly', action='store_true').scipyonly
     outfile = bsvj.read_arg('-o', '--outfile', type=str, default='test.png').outfile


### PR DESCRIPTION
Adding a new function now requires modifying the code in only two places:
1. adding a concise dictionary of expressions and ranges to `all_pdfs`;
2. adding to the list in `known_pdfs()`.

I have kept the new functions I tried in `all_pdfs` for reference, though they either do not converge well (`modexp` and `polpow` for npars>2) or give worse fits than our current functions (`ua2mod`).