### PR TITLE
Feature: Injecting Signals at Expected Limit Strength

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python quick_plot.py bkgfit ua2 --bkg cutbased/merged_20240920/bkg_sel-cutbased.
 
 ΔNNL as a function of mu:
 ```bash
-python quick_plot.py muscan scans_Dec07/*bdt0p3*Scan*.root
+python quick_plot.py muscan scans_20241029/*bdt0p3*Scan*.root
 ```
 
 Single parameter as a function of mu:
@@ -148,29 +148,48 @@ but these options can easily configured in the command line without needing to a
 # Default settings
 ./run_bias_or_self_study.sh
 
-# Run the bias test for the cut based search with a r_inj = 0.2 for mZ 200
-./run_bias_or_self_study.sh --sel cutbased --test_type bias --siginj 0.2 --mMed_values "200"
+# Run the bias test for the cut based search with a r_inj at expected limit strength for mZ 200
+./run_bias_or_self_study.sh --sel cutbased --test_type bias --siginj --mMed_values "200"
 ```
 
 Then to plot the results
 
 ```bash
-python3 plot_bias_or_self_study.py --base_dir ./self_test --sel bdt=0.65 --test self --inj 0.2
+python3 plot_bias_or_self_study.py --base_dir ./self_test --sel bdt=0.67 --test self
 ```
 
 This plotting script can be configured for the bias test, self test, bdt search, cutbased search, and various injected signal levels.
 
+Example from the BDT based search:
+```bash
+# Self test
+# no signal injected
+./run_bias_or_self_test.sh 
+# signal injected
+./run_bias_or_self_test.sh --siginj
+# plot
+python3 plot_bias_or_self_study.py --base_dir ./self_test --sel bdt=0.67 --test self
+
+# Bias test
+# no signal injected
+./run_bias_or_self_study.sh --test_type bias
+# signal injected
+./run_bias_or_self_study.sh --test_type bias --siginj
+# plot
+python3 plot_bias_or_self_study.py --base_dir ./bias_test --sel bdt=0.67 --test bias
+```
+
 ### Limits: Expected + Observed = Asimov toy with signal injected at 350
 
 This shell script works in a similar way to the previous in that it is loaded with a number of default settings that can be re-configured on the 
-command line. It defaults to running from 200 to 550 with rinv=0.3 and mdark=10 for the bdt based search.
+command line. It defaults to running from 200 to 550 with rinv=0.3 and mdark=10 for the bdt based search. Signal injection mass and a strength
+and mass can be configured.
 
 ```bash
-# Default settings
-/run_limit_asimov_sig_inj.sh
-
-# Run the test on the cutbased search for values of 300 and 350
-/run_limit_asimov_sig_inj.sh --sel cutbased --mMed_values "300 350"
+# Running with signal injected at mZ' 200 with a strength of 0.271
+./run_limit_asimov_sig_inj.sh --mInj 200 --siginj 0.271
+# Then to run all signal masses
+./all_sig_inj_asimov_limits.sh
 ```
 
 If you redo the tests multiple times, make sure to provide clean directories

--- a/README.md
+++ b/README.md
@@ -164,17 +164,17 @@ Example from the BDT based search:
 ```bash
 # Self test
 # no signal injected
-./run_bias_or_self_test.sh 
-# signal injected
-./run_bias_or_self_test.sh --siginj
+./run_bias_or_self_test.sh --siginj 0
+# signal injected at expected limit
+./run_bias_or_self_test.sh --siginj exp
 # plot
 python3 plot_bias_or_self_study.py --base_dir ./self_test --sel bdt=0.67 --test self
 
 # Bias test
 # no signal injected
-./run_bias_or_self_study.sh --test_type bias
-# signal injected
-./run_bias_or_self_study.sh --test_type bias --siginj
+./run_bias_or_self_study.sh --test_type bias --siginj 0
+# signal injected at expected limit
+./run_bias_or_self_study.sh --test_type bias --siginj exp
 # plot
 python3 plot_bias_or_self_study.py --base_dir ./bias_test --sel bdt=0.67 --test bias
 ```
@@ -188,7 +188,7 @@ and mass can be configured.
 ```bash
 # Running with signal injected at mZ' 200 with a strength of 0.271
 ./run_limit_asimov_sig_inj.sh --mInj 200 --siginj 0.271
-# Then to run all signal masses
+# Or to run all signal masses (at expected limit strength)
 ./all_sig_inj_asimov_limits.sh
 ```
 

--- a/all_sig_inj_asimov_limits.sh
+++ b/all_sig_inj_asimov_limits.sh
@@ -1,0 +1,30 @@
+
+#!/bin/bash
+#==============================================================================
+# all_sig_inj_asimov_limits.sh ------------------------------------------------
+#------------------------------------------------------------------------------
+# Author(s): Brendan Regnery --------------------------------------------------
+#------------------------------------------------------------------------------
+# Basic functionality:
+#   Creates limits with expected 'asimov' values with an observed limit of an
+#      asimov toy with signal injected at each z' mass
+#      (same toy for all mass points)
+#------------------------------------------------------------------------------
+# To run : ./all_sig_inj_asimov_limits.sh 
+
+mMed_values=(200 250 300 350 400 450 500 550)
+
+# Injected signal stregnth
+declare -A sig_strength # declare associative array (bash >= 4.0)
+sig_strength=( [200]=0.271 [250]=0.136 [300]=0.165 [350]=0.189 [400]=0.210 [450]=0.249 [500]=0.265 [550]=0.397 )
+
+for mMed in "${mMed_values[@]}"
+do
+  # run the full asimov expected limits only once
+  if [ "$mMed" == 200 ]; then
+    ./run_limit_asimov_sig_inj.sh --mInj ${mMed}  --siginj ${sig_strength[$mMed]} 
+  # make only the new asimov toy with signal inject as the observed limit (and plot)
+  else
+    ./run_limit_asimov_sig_inj.sh --mInj ${mMed}  --siginj ${sig_strength[$mMed]}  --only_inj
+  fi
+done

--- a/all_sig_inj_asimov_limits.sh
+++ b/all_sig_inj_asimov_limits.sh
@@ -16,7 +16,7 @@ mMed_values=(200 250 300 350 400 450 500 550)
 
 # Injected signal stregnth
 declare -A sig_strength # declare associative array (bash >= 4.0)
-sig_strength=( [200]=0.271 [250]=0.136 [300]=0.165 [350]=0.189 [400]=0.210 [450]=0.249 [500]=0.265 [550]=0.397 )
+sig_strength=( [200]=0.267 [250]=0.129 [300]=0.160 [350]=0.184 [400]=0.208 [450]=0.248 [500]=0.262 [550]=0.396 )
 
 for mMed in "${mMed_values[@]}"
 do

--- a/plot_bias_or_self_study.py
+++ b/plot_bias_or_self_study.py
@@ -47,7 +47,7 @@ def main():
         inj = {mz: args.inj_value for mz in args.mz}
     elif args.sel == 'bdt=0.67':
         # Expected limit values for bdt=0.67
-        inj_values = [0.271, 0.136, 0.165, 0.189, 0.210, 0.249, 0.265, 0.397]
+        inj_values = [0.267, 0.129, 0.160, 0.184, 0.208, 0.248, 0.262, 0.396]
         inj = {mz: inj_val for mz, inj_val in zip(args.mz, inj_values)}
     else:
         # Default case with warning

--- a/plot_bias_or_self_study.py
+++ b/plot_bias_or_self_study.py
@@ -29,7 +29,9 @@ def main():
                         help="Test type: 'bias' or 'self'")
     parser.add_argument('--mz', nargs='+', type=int, default=[200, 250, 300, 350, 400, 450, 500, 550],
                         help="List of mass points. Default is [200, 250, 300, 350, 400, 450, 500, 550]")
-    
+    parser.add_argument('--inj_value', type=float, default=None,
+                        help="Set all injection values to a specific number for testing (e.g., 0.3)")   
+ 
     args = parser.parse_args()
 
     # Switch between bias and self test
@@ -39,13 +41,18 @@ def main():
     elif test == 'self' : test_title = 'Self'
 
     # injected signal strength
-    # Needs to be aded for cutbased
-    inj ={}
-    if args.sel == 'bdt=0.67':
-        inj = {200 : 0.271, 250 : 0.136, 300 : 0.165, 350 : 0.189, 400 : 0.210, 450 : 0.249, 500 : 0.265, 550 : 0.397}
-    else :
+    # Needs to be added for cutbased
+    if args.inj_value is not None:
+        # If the user specifies --inj_value, override all injection values
+        inj = {mz: args.inj_value for mz in args.mz}
+    elif args.sel == 'bdt=0.67':
+        # Expected limit values for bdt=0.67
+        inj_values = [0.271, 0.136, 0.165, 0.189, 0.210, 0.249, 0.265, 0.397]
+        inj = {mz: inj_val for mz, inj_val in zip(args.mz, inj_values)}
+    else:
+        # Default case with warning
         print("WARNING: using 0.2 as injected signal value, please correct if unintended")
-        inj = {200 : 0.2, 250 : 0.2, 300 : 0.2, 350 : 0.2, 400 : 0.2, 450 : 0.2, 500 : 0.2, 550 : 0.2}
+        inj = {mz: 0.2 for mz in args.mz}
 
     # Directories for r_inj = 0 and r_inj = inj
     path_rinj0 = [(f"{args.base_dir}/siginj0/fitDiagnosticsObserveddc_SVJ_s-channel_mMed-{mz}_mDark-10_"

--- a/run_bias_or_self_study.sh
+++ b/run_bias_or_self_study.sh
@@ -49,7 +49,7 @@ else
     pdf_option="ua2"
 fi
 
-# This is used for the 'siginj' directory 0 means no signal, 1 means signal injected (not sig strength)
+# This is used for naming the 'siginj' directory: 0 means no signal, 1 means signal injected (not sig strength)
 if [ "$siginj" == 0 ]; then
     inj_dir=0
 else

--- a/run_bias_or_self_study.sh
+++ b/run_bias_or_self_study.sh
@@ -103,6 +103,7 @@ fi
 for mMed in "${mMed_values[@]}"
 do
   # Run the 'fittoys' command with the current mMed value and variable mDark
+  # --range is used for likelihood fits and rMin/rMax for toy fits
   python3 cli_boosted.py fittoys \
     dc_${dc_date}_${sel}/dc_SVJ_s-channel_mMed-${mMed}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.txt \
     --toysFile toys_${toys_date}/higgsCombineObserveddc_SVJ_s-channel_mMed-${mMed}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.GenerateOnly.mH120.1001.root \

--- a/run_bias_or_self_study.sh
+++ b/run_bias_or_self_study.sh
@@ -105,7 +105,7 @@ do
   # Run the 'fittoys' command with the current mMed value and variable mDark
   python3 cli_boosted.py fittoys \
     dc_${dc_date}_${sel}/dc_SVJ_s-channel_mMed-${mMed}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.txt \
-    --toysFile toys_${toys_date}/higgsCombineObserveddc_SVJ_s-channel_mMed-${mMed}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smoothNone.GenerateOnly.mH120.1001.root \
+    --toysFile toys_${toys_date}/higgsCombineObserveddc_SVJ_s-channel_mMed-${mMed}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.GenerateOnly.mH120.1001.root \
     --expectSignal 0 \
     --rMax 5 \
     --rMin -5 \

--- a/run_bias_or_self_study.sh
+++ b/run_bias_or_self_study.sh
@@ -13,16 +13,16 @@
 # ./run_bias_study.sh -d 20240930 -f --sel cutbased --test_type bias --siginj 1.0 --mMed_values "200 300 500"
 
 # Default values
-hists_date="20240919"   # Date of the histograms used to make the data cards
+hists_date="20241115"   # Date of the histograms used to make the data cards
 dc_date=$(date +%Y%m%d)     # Today's date for gentoys command
 toys_date=$(date +%Y%m%d)   # Today's date for fittoys command
 toyfits_date=$(date +%b%d)  # Date format for toyfits directory as "Oct29"
 mDark_value="10"
 rinv_value="0p3"
 run_only_fits=false         # Default to generate datacards, toys, and fit
-sel="bdt=0.65"            # Default selection type
+sel="bdt=0.67"            # Default selection type
 test_type="self"            # Default test type
-siginj=0.0                  # Default injected signal value
+siginj=false                  # Default no signal injected
 mMed_values=(200 250 300 350 400 450 500 550)  # Default mMed values
 
 # Parse command-line arguments
@@ -33,7 +33,7 @@ while [[ "$#" -gt 0 ]]; do
         --sel) sel="$2"; shift ;;
         --test_type) test_type="$2"; shift ;;
         --hists_date) hists_date="$2"; shift ;;
-        --siginj) siginj="$2"; shift ;;
+        --siginj) siginj=true ;;
         --mDark) mDark_value="$2"; shift ;;
         --rinv) rinv_value="$2"; shift ;; 
         --mMed_values) IFS=' ' read -r -a mMed_values <<< "$2"; shift ;;  # Parse mMed_values as array
@@ -50,14 +50,19 @@ else
 fi
 
 # This is used for the 'siginj' directory 0 means no signal, 1 means signal injected (not sig strength)
-if (( $(echo "$siginj == 0" | bc -l) )); then
+if [ "$siginj" == false ]; then
     inj=0
 else
     inj=1
 fi
 
+# Injected signal stregnth
+declare -A sig_strength # declare associative array (bash >= 4.0)
+sig_strength=( [200]=0.271 [250]=0.136 [300]=0.165 [350]=0.189 [400]=0.210 [450]=0.249 [500]=0.265 [550]=0.397 )
+# Cut-based values are needed!!
+
 # Generate the datacards (skip if only running fits)
-if [ "$run_only_fits" = false ]; then
+if [ "$run_only_fits" == false ]; then
   for mMed in "${mMed_values[@]}"
   do
     # Generate datacards for the current mMed value with variable mDark and hists_date
@@ -69,13 +74,24 @@ if [ "$run_only_fits" = false ]; then
   # First loop: Run the 'gentoys' command
   for mMed in "${mMed_values[@]}"
   do
-    # Run the 'gentoys' command with the current mMed value and variable mDark
-    python3 cli_boosted.py gentoys \
-      dc_${dc_date}_${sel}/dc_SVJ_s-channel_mMed-${mMed}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.txt \
-      -t 300 \
-      --expectSignal $siginj \
-      -s 1001 \
-      --pdf $pdf_option
+    if [ "$siginj" == true ]; then
+      # Run the 'gentoys' command with the current mMed value and variable mDark
+      python3 cli_boosted.py gentoys \
+        dc_${dc_date}_${sel}/dc_SVJ_s-channel_mMed-${mMed}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.txt \
+        -t 300 \
+        --expectSignal ${sig_strength[$mMed]} \
+        -s 1001 \
+        --pdf $pdf_option
+    else
+      # Run the 'gentoys' command with the current mMed value and variable mDark
+      # no signal injected
+      python3 cli_boosted.py gentoys \
+        dc_${dc_date}_${sel}/dc_SVJ_s-channel_mMed-${mMed}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.txt \
+        -t 300 \
+        --expectSignal 0 \
+        -s 1001 \
+        --pdf $pdf_option
+    fi
   done
 fi
 

--- a/run_bias_or_self_study.sh
+++ b/run_bias_or_self_study.sh
@@ -51,15 +51,15 @@ fi
 
 # This is used for the 'siginj' directory 0 means no signal, 1 means signal injected (not sig strength)
 if [ "$siginj" == 0 ]; then
-    inj=0
+    inj_dir=0
 else
-    inj=1
+    inj_dir=1
 fi
 
 # Injected signal stregnth
 declare -A sig_strength # declare associative array (bash >= 4.0)
 if [ "$siginj" == "exp" ]; then
-    sig_strength=( [200]=0.271 [250]=0.136 [300]=0.165 [350]=0.189 [400]=0.210 [450]=0.249 [500]=0.265 [550]=0.397 )
+    sig_strength=( [200]=0.267 [250]=0.129 [300]=0.160 [350]=0.184 [400]=0.208 [450]=0.248 [500]=0.262 [550]=0.396 )
     # Cut-based values are needed!!
 else
     sig_strength=( [200]=$siginj [250]=$siginj [300]=$siginj [350]=$siginj [400]=$siginj [450]=$siginj [500]=$siginj [550]=$siginj )
@@ -114,7 +114,7 @@ do
 done
 
 # Create the results directory that is expected by the plotting code
-results_dir="${test_type}_test/siginj${inj}"
+results_dir="${test_type}_test/siginj${inj_dir}"
 mkdir -p "$results_dir"
 
 # Copy the ROOT files from the generated toyfits directory to the new results directory

--- a/run_limit_asimov_sig_inj.sh
+++ b/run_limit_asimov_sig_inj.sh
@@ -13,23 +13,28 @@
 # To run with a specfic date: ./run_limit_asimov_sig_inj.sh --mMed_values "300 350"
 
 # Default values
-hists_date="20240919"  # Date of the histograms used for making datacards
+hists_date="20241115"  # Date of the histograms used for making datacards
 dc_date=$(date +%Y%m%d)    # Dynamically set today's date 
 scan_date=$(date +%Y%m%d)  
-sel="bdt=0.65"
+sel="bdt=0.67"
+siginj=0.2
+mInj=350
 mDark_value="10"
 rinv_value="0p3"
 mMed_values=(200 250 300 350 400 450 500 550)
 run_only_fits=false        # Default to running all loops
+only_inj=false
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -d) toys_date="$2"; shift ;; 
         -f) run_only_fits=true ;; # option to only run likelihood scan
+        --only_inj) only_inj=true ;; # only generates and fits 'observed' signal injected asimov toy
         --sel) sel="$2"; shift ;;
         --hists_date) hists_date="$2"; shift ;;
         --siginj) siginj="$2"; shift ;;
+        --mInj) mInj="$2"; shift ;;
         --mDark) mDark_value="$2"; shift ;;
         --rinv) rinv_value="$2"; shift ;; 
         --mMed_values) IFS=' ' read -r -a mMed_values <<< "$2"; shift ;;  # Parse mMed_values as array
@@ -50,21 +55,23 @@ if [ "$run_only_fits" = false ]; then
       --sig hists/smooth_${hists_date}/SVJ_s-channel_mMed-${mMed}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.json
   done
 
-  # Generate an asimov toy with a signal at 350 GeV
+  # Generate an asimov toy with a signal at requested Zprime mass
   python3 cli_boosted.py gentoys \
-    dc_${dc_date}_${sel}/dc_SVJ_s-channel_mMed-350_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.txt  \
+    dc_${dc_date}_${sel}/dc_SVJ_s-channel_mMed-${mInj}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.txt  \
     -t -1 \
-    --expectSignal 0.2 \
+    --expectSignal ${siginj} \
     -s 1001
 
   # Likelihood scan for expected limits
   # These become the 'asimov' files
-  python3 cli_boosted.py likelihood_scan_mp \
-    dc_${dc_date}_${sel}/dc*mDark-${mDark_value}_rinv-${rinv_value}*${sel}*smooth.txt \
-    --rMin 0.0 \
-    --rMax 5.0 \
-    --seed 1001 \
-    --asimov
+  if [ "$only_inj" = false ]; then
+    python3 cli_boosted.py likelihood_scan_mp \
+      dc_${dc_date}_${sel}/dc*mDark-${mDark_value}_rinv-${rinv_value}*${sel}*smooth.txt \
+      --rMin 0.0 \
+      --rMax 5.0 \
+      --seed 1001 \
+      --asimov
+  fi
 
 fi
 
@@ -76,11 +83,11 @@ python3 cli_boosted.py likelihood_scan_mp \
   --rMax 5.0 \
   --seed 1001 \
   -t -1 \
-  --toysFile toys_${dc_date}/higgsCombineObserveddc_SVJ_s-channel_mMed-350_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.GenerateOnly.mH120.1001.root
+  --toysFile toys_${dc_date}/higgsCombineObserveddc_SVJ_s-channel_mMed-${mInj}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.GenerateOnly.mH120.1001.root
 
 # plot
 python3 quick_plot.py brazil \
   scans_${dc_date}/higgsCombine*rinv-${rinv_value}*.root \
-  -o asimov_350sig_test_${rinv_value}_mdark${mDark_value}.pdf
+  -o asimov_${mInj}_sig_test_${rinv_value}_mdark${mDark_value}.pdf
 
 

--- a/run_limit_asimov_sig_inj.sh
+++ b/run_limit_asimov_sig_inj.sh
@@ -67,8 +67,7 @@ if [ "$run_only_fits" = false ]; then
   if [ "$only_inj" = false ]; then
     python3 cli_boosted.py likelihood_scan_mp \
       dc_${dc_date}_${sel}/dc*mDark-${mDark_value}_rinv-${rinv_value}*${sel}*smooth.txt \
-      --rMin 0.0 \
-      --rMax 5.0 \
+      --range 0.0 2.0 \
       --seed 1001 \
       --asimov
   fi
@@ -79,11 +78,10 @@ fi
 # These become the 'observed' files
 python3 cli_boosted.py likelihood_scan_mp \
   dc_${dc_date}_${sel}/dc*mDark-${mDark_value}_rinv-${rinv_value}*${sel}*smooth.txt \
-  --rMin 0.0 \
-  --rMax 5.0 \
+  --range 0.0 2.0 \
   --seed 1001 \
-  -t -1 \
-  --toysFile toys_${dc_date}/higgsCombineObserveddc_SVJ_s-channel_mMed-${mInj}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.GenerateOnly.mH120.1001.root
+  --toysFile toys_${dc_date}/higgsCombineObserveddc_SVJ_s-channel_mMed-${mInj}_mDark-${mDark_value}_rinv-${rinv_value}_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-${sel}_smooth.GenerateOnly.mH120.1001.root \
+  -t -1
 
 # plot
 python3 quick_plot.py brazil \


### PR DESCRIPTION
This addresses issue #9 changing the higher level statistical tests to inject signal at the expected limit strength. This is done for the bias test, self test, and asimov signal injected limit test.

The documentation has been updated accordingly.

The code has been tested be rerunning all of these tests for the bdt-based search.

One caveat, as I did not know the expected limits of the cut-based search, I did not include these. However, I left space in the code for it to be easily added to run at expected limit strength also for the cut-based.