### PR TITLE
Various fit and feature improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,21 +87,25 @@ python3 cli_boosted.py impacts dc.txt --nfits 16 --asimov --normRange 0.1 2.0 --
 ```
 
 ## Plotting
-Bkg fit 
 
+Fit to background distribution:
 ```bash
-python3 quick_plot.py bkgfit ua2 --bkg cutbased/merged_20240920/bkg_sel-cutbased.json --sig cutbased/smooth_20240920/SVJ_s-channel_mMed-350_mDark-10_rinv-0p3_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-cutbased_smooth.json --outfile fit_bkg.png
+python quick_plot.py bkgfit ua2 --bkg cutbased/merged_20240920/bkg_sel-cutbased.json --sig cutbased/smooth_20240920/SVJ_s-channel_mMed-350_mDark-10_rinv-0p3_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-cutbased_smooth.json --outfile fit_bkg.png
 ```
 
 ΔNNL as a function of mu:
-
 ```bash
 python quick_plot.py muscan scans_Dec07/*bdt0p3*Scan*.root
 ```
 
-Fit to background distribution:
+Single parameter as a function of mu:
 ```bash
-python3 quick_plot.py bkgfit ua2 --bkg merged_20240729/bkg_sel-cutbased.json --sig smooth_20240729/SVJ_s-channel_mMed-350_mDark-10_rinv-0p3_alpha-peak_MADPT300_13TeV-madgraphMLM-pythia8_sel-cutbased_smooth.json --outfile fit_bkg.png
+python quick_plot.py trackedparam bsvj_bkgfitua2_npars3_p1 scans_cutbased/*Scan*.root
+```
+
+All fit parameters as a function of mu:
+```bash
+python quick_plot.py trackedparams scans_cutbased/*Scan*.root
 ```
 
 MT histogram, with bkg-only fit and and sig+bkg fit:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@
 Current results are using release `CMSSW_11_3_4`, tag v9.1.0.
 Make sure to install `CombineHarvester` as well (bottom of that page).
 
-2. Clone this repository:
+2. Clone this repository and install dependencies:
 
 ```bash
 cd $CMSSW_BASE/src
+cmsenv
+scram-venv
+cmsenv
+pip3 install git+https://github.com/boostedsvj/seutils
+pip3 install git+https://github.com/boostedsvj/svj_ntuple_processing
 git clone git@github.com:boostedsvj/svj_limits.git boosted/svj_limits
 cd boosted/svj_limits
 ```

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -507,7 +507,7 @@ class InputData(object):
     def n_bins(self):
         return len(self.mt)-1
 
-    def gen_datacard(self, use_cache=True, fit_cache_lock=None):
+    def gen_datacard(self, use_cache=True, fit_cache_lock=None, nosyst=False):
         mz = int(self.metadata['mz'])
         rinv = float(self.metadata['rinv'])
         mdark = int(self.metadata['mdark'])
@@ -565,7 +565,12 @@ class InputData(object):
                 used_systs.add(syst_name)
             syst_th1s.append(hist.th1(f'{sig_name}_{syst_name}{direction}'))
 
-        outfile = strftime(f'dc_%Y%m%d_{self.metadata["selection"]}/dc_{osp.basename(self.sigfile).replace(".json","")}.txt')
+        nosystname = ""
+        if nosyst:
+            systs = [s for s in systs if s[1]=='extArg']
+            nosystname = "_nosyst"
+
+        outfile = strftime(f'dc_%Y%m%d_{self.metadata["selection"]}{nosystname}/dc_{osp.basename(self.sigfile).replace(".json","")}{nosystname}.txt')
         compile_datacard_macro(
             winner_pdfs, data_datahist, sig_datahist,
             outfile,

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -1681,10 +1681,10 @@ class CombineCommand(object):
             logger.info('Doing asimov')
             self.kwargs['-t'] = -1
             self.args.add('--toysFrequentist')
-            self.name = 'Asimov'
+            self.name += 'Asimov'
         else:
             logger.info('Doing observed')
-            self.name = 'Observed'
+            self.name += 'Observed'
 
     def configure_from_command_line(self):
         """

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -1508,10 +1508,9 @@ def make_multipdf(pdfs, name='roomultipdf'):
     multipdf = ROOT.RooMultiPdf(name, "All Pdfs", cat, pdf_arglist)
     multipdf.cat = cat
     multipdf.pdfs = pdfs
-    norm_nominal = ROOT.RooRealVar(name+'_nominal', "Nominal component", 1.0, 0., 1.e6)
     norm_theta = ROOT.RooRealVar(name+'_theta', "Extra component", 0.01, -10., 10.)
-    norm = ROOT.RooFormulaVar(name+'_norm', "@0+0.01*@1*sqrt(@0)", ROOT.RooArgList(norm_nominal,norm_theta))
-    norm_objs = [norm_nominal, norm_theta, norm]
+    norm = ROOT.RooFormulaVar(name+'_norm', "1+0.01*@0", ROOT.RooArgList(norm_theta))
+    norm_objs = [norm_theta, norm]
     object_keeper.add_multiple([cat, norm_objs, multipdf])
     return multipdf, norm_objs
 

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -1415,7 +1415,7 @@ def read_dc_txt(txt):
         if len(syst) >= 3:
             try:
                 syst[2] = float(syst[2])
-            except TypeError:
+            except:
                 pass
         if len(syst)>1 and syst[1]=='extArg':
             dc.extargs.append(syst)

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -1671,12 +1671,16 @@ class CombineCommand(object):
         logger.info('Using pdf %s', pdf)
         self.set_parameter('pdf_index', known_pdfs().index(pdf))
         pdf_pars = self.dc.syst_rgx('bsvj_bkgfit%s_npars*' % pdf)
-        self.track_parameters.update(['r', 'n_exp_final_binbsvj_proc_roomultipdf'] + pdf_pars)
+        pars_to_track = ['r', 'n_exp_final_binbsvj_proc_roomultipdf', 'shapeBkg_roomultipdf_bsvj__norm', 'roomultipdf_theta'] + pdf_pars
+        self.track_parameters.update(pars_to_track)
+        self.track_errors.update(pars_to_track)
         self.freeze_parameters.add('pdf_index')
         for other_pdf in known_pdfs():
             if other_pdf==pdf: continue
             other_pdf_pars = self.dc.syst_rgx('bsvj_bkgfit%s_npars*' % other_pdf)
             self.freeze_parameters.update(other_pdf_pars)
+        # extargs do not have errors
+        self.track_parameters.update([x[0] for x in self.dc.extargs])
 
     def asimov(self, flag=True):
         """

--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -1508,7 +1508,7 @@ def make_multipdf(pdfs, name='roomultipdf'):
     multipdf = ROOT.RooMultiPdf(name, "All Pdfs", cat, pdf_arglist)
     multipdf.cat = cat
     multipdf.pdfs = pdfs
-    norm_theta = ROOT.RooRealVar(name+'_theta', "Extra component", 0.01, -10., 10.)
+    norm_theta = ROOT.RooRealVar(name+'_theta', "Extra component", 0.01, -100., 100.)
     norm = ROOT.RooFormulaVar(name+'_norm', "1+0.01*@0", ROOT.RooArgList(norm_theta))
     norm_objs = [norm_theta, norm]
     object_keeper.add_multiple([cat, norm_objs, multipdf])

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -156,7 +156,8 @@ def gen_datacards():
     mtmax = bsvj.pull_arg('--mtmax', type=float, default=None).mtmax
     if mtmin is not None: jsons["mt_min"] = mtmin
     if mtmax is not None: jsons["mt_max"] = mtmax
-    bsvj.InputData(**jsons).gen_datacard()
+    nosyst = bsvj.pull_arg('--nosyst', default=False, action="store_true").nosyst
+    bsvj.InputData(**jsons).gen_datacard(nosyst=nosyst)
 
 @scripter
 def simple_test_fit():

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -186,12 +186,13 @@ def make_bestfit_and_scan_commands(txtfile, args=None):
     with bsvj.set_args(sys.argv[:1] + args):
         dc = bsvj.Datacard.from_txt(txtfile)
         cmd = bsvj.CombineCommand(dc)
-        cmd.configure_from_command_line()
         cmd.name += osp.basename(dc.filename).replace('.txt','')
         scan = bsvj.scan(cmd)
-        bestfit = bsvj.bestfit(cmd)
         scan.name += 'Scan'
+        scan.configure_from_command_line()
+        bestfit = bsvj.bestfit(cmd)
         bestfit.name += 'Bestfit'
+        bestfit.configure_from_command_line()
     return bestfit, scan
 
 

--- a/quick_plot.py
+++ b/quick_plot.py
@@ -12,6 +12,7 @@ import argparse
 import sys, os, os.path as osp, pprint, re, traceback, copy, fnmatch, shutil
 from contextlib import contextmanager
 sys.path.append(osp.dirname(osp.abspath(__file__)))
+import svj_ntuple_processing as svj
 import boosted_fits as bsvj
 logger = bsvj.setup_logger('quickplot')
 
@@ -73,10 +74,10 @@ def namespace_to_attrdict(args):
     return bsvj.AttrDict(**vars(args))
 
 def get_mz(path):
-    return int(re.search(r'mz(\d+)', osp.basename(path)).group(1))
+    return svj.metadata_from_path(path)['mz']
 
 def get_rinv(path):
-    return int(re.search(r'rinv([\d\.]+)', osp.basename(path)).group(1))
+    return svj.metadata_from_path(path)['rinv']
 
 def get_bdt_str(path):
     return re.search(r'bdt([p\d]+)', osp.basename(path)).group(1)

--- a/quick_plot.py
+++ b/quick_plot.py
@@ -64,10 +64,23 @@ def quick_ax(figsize=(12,12), outfile='test.png'):
 
 
 def name_from_combine_rootfile(rootfile, strip_obs_asimov=False):
-    name = osp.basename(rootfile).rsplit('.',3)[0].replace('higgsCombine','')
-    if strip_obs_asimov:
-        name = name.replace('Observed_','').replace('Asimov_','')
-    name = name.replace('.MultiDimFit','')
+    param_tex = {
+        'mz': r'm_{\mathrm{Z}^{\prime}}',
+        'mdark': r'm_{\mathrm{dark}}',
+        'rinv': r'r_{\mathrm{inv}}',
+    }
+    meta = svj.metadata_from_path(rootfile)
+    if meta['sample_type']=='sig':
+        names = ['']
+        if not strip_obs_asimov:
+            names = [x for x in ['Observed','Asimov'] if x in rootfile]+names
+        name = names[0]
+        name += ' ($'+', '.join(val+'='+str(meta[key]) for key,val in param_tex.items())+'$)'
+    else:
+        name = osp.basename(rootfile).rsplit('.',3)[0].replace('higgsCombine','')
+        if strip_obs_asimov:
+            name = name.replace('Observed_','').replace('Asimov_','')
+        name = name.replace('.MultiDimFit','')
     return name
 
 def namespace_to_attrdict(args):


### PR DESCRIPTION
1. After analysis of the Hessian matrix, the large condition number was found to be due primarily to the background normalization parameter, whose uncertainty was much smaller than its value. Rescaling to `norm = 1 + 0.01*theta` results in the parameter theta having an error closer to its magnitude, improving the Hessian condition by an order of magnitude. The range of theta is currently set to [-100,100], but this should be checked for extreme signal points, as it may need to be extended further.
2. Fix naming of likelihood scan output files and signals in legends. (relies on `svj_ntuple_processing`, now added to installation instructions.)
3. Fix order of operations in preparing likelihood scan commands so that command-line arguments are passed through correctly (resolves #4).
4. Track extargs in likelihood scans (resolves #5), and track errors of fit parameters.
5. New function to plot all fit parameters vs. mu (anything that has a tracked error). Error bands are now included in these plots.
6. Option to make datacards with signal systematics disabled (used for Hessian testing).