### PR TITLE
Updates for bias studies

### DIFF
--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -1722,6 +1722,9 @@ class CombineCommand(object):
         else:
             logger.info('Doing observed')
             self.name += 'Observed'
+            if read_arg("--tIsToyIndex", default=False, action="store_true").tIsToyIndex:
+                toy_index = read_arg('-t', type=int).t
+                self.name += f'Toy{toy_index}'
 
     def configure_from_command_line(self, scan=False):
         """

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -158,7 +158,8 @@ def gen_datacards():
     if mtmin is not None: jsons["mt_min"] = mtmin
     if mtmax is not None: jsons["mt_max"] = mtmax
     nosyst = bsvj.pull_arg('--nosyst', default=False, action="store_true").nosyst
-    bsvj.InputData(**jsons).gen_datacard(nosyst=nosyst, gof_type=gof_type)
+    asimov = bsvj.pull_arg('--asimov', default=False, action="store_true").asimov
+    bsvj.InputData(**jsons, asimov=asimov).gen_datacard(nosyst=nosyst, gof_type=gof_type)
 
 @scripter
 def simple_test_fit():

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -159,7 +159,9 @@ def gen_datacards():
     if mtmax is not None: jsons["mt_max"] = mtmax
     nosyst = bsvj.pull_arg('--nosyst', default=False, action="store_true").nosyst
     asimov = bsvj.pull_arg('--asimov', default=False, action="store_true").asimov
-    bsvj.InputData(**jsons, asimov=asimov).gen_datacard(nosyst=nosyst, gof_type=gof_type)
+    winner = bsvj.pull_arg('--winner', default=None, nargs=2, action="append").winner
+    winners = {a:int(b) for a,b in winner} if winner is not None else None
+    bsvj.InputData(**jsons, asimov=asimov).gen_datacard(nosyst=nosyst, gof_type=gof_type, winners=winners)
 
 @scripter
 def simple_test_fit():

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -219,6 +219,10 @@ def bestfit(txtfile=None):
         else:
             txtfile = osp.abspath(txtfiles[0])
 
+    outdir = bsvj.pull_arg('-o', '--outdir', type=str, default=strftime('bestfits_%Y%m%d')).outdir
+    outdir = osp.abspath(outdir)
+    os.makedirs(outdir, exist_ok=True)
+
     dc = bsvj.Datacard.from_txt(txtfile)
     cmd = bsvj.CombineCommand(dc)
     cmd.configure_from_command_line()
@@ -227,9 +231,6 @@ def bestfit(txtfile=None):
     cmd.name += 'Bestfit_' + osp.basename(txtfile).replace('.txt','')
     bsvj.run_combine_command(cmd, logfile=cmd.logfile)
 
-    outdir = bsvj.pull_arg('-o', '--outdir', type=str, default=strftime('bestfits_%Y%m%d')).outdir
-    outdir = osp.abspath(outdir)
-    os.makedirs(outdir, exist_ok=True)
     bsvj.logger.info(f'{cmd.outfile} -> {osp.join(outdir, osp.basename(cmd.outfile))}')
     shutil.move(cmd.outfile, osp.join(outdir, osp.basename(cmd.outfile)))
     shutil.move(cmd.logfile, osp.join(outdir, osp.basename(cmd.logfile)))

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -161,7 +161,8 @@ def gen_datacards():
     asimov = bsvj.pull_arg('--asimov', default=False, action="store_true").asimov
     winner = bsvj.pull_arg('--winner', default=None, nargs=2, action="append").winner
     winners = {a:int(b) for a,b in winner} if winner is not None else None
-    bsvj.InputData(**jsons, asimov=asimov).gen_datacard(nosyst=nosyst, gof_type=gof_type, winners=winners)
+    brute = bsvj.pull_arg('--brute', default=False, action="store_true").brute
+    bsvj.InputData(**jsons, asimov=asimov).gen_datacard(nosyst=nosyst, gof_type=gof_type, winners=winners, brute=brute)
 
 @scripter
 def simple_test_fit():

--- a/quick_plot.py
+++ b/quick_plot.py
@@ -845,7 +845,7 @@ def bkgfit():
     linscale = bsvj.pull_arg('--lin', action='store_true').lin
     scipyonly = bsvj.pull_arg('--scipyonly', action='store_true').scipyonly
     outfile = bsvj.read_arg('-o', '--outfile', type=str, default='test.png').outfile
-    gof_type = bsvj.pull_arg('--gof-type', type=str, default='chi2', choices=['chi2','rss']).gof_type
+    gof_type = bsvj.pull_arg('--gof-type', type=str, default='rss', choices=['chi2','rss']).gof_type
 
     input = bsvj.InputData(**jsons)
 

--- a/quick_plot.py
+++ b/quick_plot.py
@@ -410,7 +410,6 @@ def mtdist():
     rootfile = bsvj.pull_arg('rootfile', type=str).rootfile
     only_sig = bsvj.pull_arg('--onlysig', action='store_true').onlysig
     outfile = bsvj.read_arg('-o', '--outfile', type=str, default='muscan.png').outfile
-    #toyrootfile = bsvj.pull_arg('--toyrootfile', type=str).toyrootfile
 
     from scipy.interpolate import make_interp_spline # type:ignore
 
@@ -457,10 +456,6 @@ def mtdist():
     y_data = bsvj.roodataset_values(data)[1]
 
     # Get histogram from generated toy
-    #with bsvj.open_root(toyrootfile) as f:
-    #  toy = f.Get("toys/toy_1")
-    #data = ROOT.RooDataSet(toy,'mt')
-    #y_data = bsvj.roodataset_values(data)[1]
     errs_data = np.sqrt(y_data)
     logger.info(f'Prefit data # entries = {y_data.sum():.2f}, should match with datacard')
 
@@ -514,7 +509,6 @@ def mtdist():
             xerr=.5*mt_bin_widths, yerr=errs_data,
             fmt='o', c='black', label='Data'
             )
-        # logger.warning('data (roodst):  %s', y_data)
 
         ax.step(mt_binning[:-1], y_bkg_init, where='post', c='purple', label=r'$B_{prefit}$')
         ax2.step(

--- a/run_bias_or_self_study.sh
+++ b/run_bias_or_self_study.sh
@@ -76,7 +76,7 @@ else
 fi
 
 # Generate the datacards (skip if only running fits)
-if [ "$run_only_fits" == false ] || [ "$skip_dc" == false ]; then
+if [ "$run_only_fits" == false ] && [ "$skip_dc" == false ]; then
   for mMed in "${mMed_values[@]}"
   do
     get_signame

--- a/run_bias_or_self_study.sh
+++ b/run_bias_or_self_study.sh
@@ -81,9 +81,9 @@ if [ "$run_only_fits" == false ] || [ "$skip_dc" == false ]; then
   do
     get_signame
     # Generate datacards for the current mMed value with variable mDark and hists_date
-    python3 cli_boosted.py gen_datacards \
+    (set -x; python3 cli_boosted.py gen_datacards \
       --bkg hists/merged_${hists_date}/bkg_sel-${sel}.json \
-      --sig hists/smooth_${hists_date}/${sig_name}.json
+      --sig hists/smooth_${hists_date}/${sig_name}.json)
   done
 fi
 
@@ -97,12 +97,12 @@ if [ "$run_only_fits" == false ]; then
 	  expect_sig=${sig_strength[$mMed]}
 	fi
     # Run the 'gentoys' command with the current mMed value and variable mDark
-    python3 cli_boosted.py gentoys \
+    (set -x; python3 cli_boosted.py gentoys \
       dc_${dc_date}_${sel}/dc_${sig_name}.txt \
       -t 300 \
       --expectSignal ${expect_sig} \
       -s ${toy_seed} \
-      --pdf $pdf_option
+      --pdf ${pdf_option})
   done
 fi
 
@@ -112,14 +112,14 @@ do
   get_signame
   # Run the 'fittoys' command with the current mMed value and variable mDark
   # --range is used for likelihood fits and rMin/rMax for toy fits
-  python3 cli_boosted.py fittoys \
+  (set -x; python3 cli_boosted.py fittoys \
     dc_${dc_date}_${sel}/dc_${sig_name}.txt \
     --toysFile toys_${toys_date}/higgsCombineObserveddc_${sig_name}.GenerateOnly.mH120.${toy_seed}.root \
     --expectSignal 0 \
     --rMax ${rmax} \
     --rMin -${rmax} \
     --pdf ua2 \
-    --cminDefaultMinimizerStrategy=0
+    --cminDefaultMinimizerStrategy=0)
 done
 
 # Create the results directory that is expected by the plotting code

--- a/run_bias_or_self_study.sh
+++ b/run_bias_or_self_study.sh
@@ -26,6 +26,7 @@ sel="bdt=0.67"            # Default selection type
 test_type="self"            # Default test type
 siginj="exp"                  # Default signal injected at exp limit strength
 mMed_values=(200 250 300 350 400 450 500 550)  # Default mMed values
+rmax=5
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
@@ -38,6 +39,7 @@ while [[ "$#" -gt 0 ]]; do
         --dc_date) dc_date="$2"; shift ;;
         --hists_date) hists_date="$2"; shift ;;
         --siginj) siginj="$2"; shift ;;
+        --rmax) rmax="$2"; shift ;;
         --mDark) mDark_value="$2"; shift ;;
         --rinv) rinv_value="$2"; shift ;; 
         --mMed_values) IFS=' ' read -r -a mMed_values <<< "$2"; shift ;;  # Parse mMed_values as array
@@ -114,8 +116,8 @@ do
     dc_${dc_date}_${sel}/dc_${sig_name}.txt \
     --toysFile toys_${toys_date}/higgsCombineObserveddc_${sig_name}.GenerateOnly.mH120.${toy_seed}.root \
     --expectSignal 0 \
-    --rMax 5 \
-    --rMin -5 \
+    --rMax ${rmax} \
+    --rMin -${rmax} \
     --pdf ua2 \
     --cminDefaultMinimizerStrategy=0
 done


### PR DESCRIPTION
* fix mistakes leftover from #15 and #13
* improve consistency in run_bias... and add some more arguments
* add option to pick out specific toy in MultiDimFit (https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/compare/v9.2.0...boostedsvj:HiggsAnalysis-CombinedLimit:seed_fit updated accordingly) for bestfit inspection:
    ```bash
    NTOY=2
    python3 cli_boosted.py bestfit [dc] -t ${NTOY} --tIsToyIndex --saveToys --toysFile [tf]
    python3 quick_plot.py mtdist [bf] --outfile postfit_toy${NTOY}.png
    ```
* improve postfit plot formatting, content; display toy data when used
* new handles to:
    * pick winning pdf index manually
    * force the initial fit to use brute force
* option to make datacard from Asimov dataset (in order to fit one pdf to another pdf)
