### PR TITLE
Fixes for impacts and asimov study

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cmsenv
 scram-venv
 cmsenv
 git clone git@github.com:boostedsvj/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit -b seed_fit
-git clone https://github.com/cms-analysis/CombineHarvester.git CombineHarvester
+git clone https://github.com/cms-analysis/CombineHarvester.git CombineHarvester && cd CombineHarvester && git checkout 610d8ded8d1f71ed4db4d634cd9e2d7b8ae7b560 && cd -
 scram b -j 4
 pip3 install git+https://github.com/boostedsvj/seutils
 pip3 install git+https://github.com/boostedsvj/svj_ntuple_processing

--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -428,7 +428,6 @@ def impacts():
         if 'mcstat' in syst: continue
         if syst in base_cmd.freeze_parameters: continue
         systs.append(syst)
-    systs.append('shapeBkg_roomultipdf_bsvj__norm')
     bsvj.logger.info(f'Doing systematics: {" ".join(systs)}')
 
     # calculate all impacts

--- a/quick_plot.py
+++ b/quick_plot.py
@@ -828,7 +828,7 @@ def brazil():
 
     with quick_ax(figsize=(12,10), outfile=outfile) as ax:
         ax.plot([],[],label='95% CL upper limits (cut-based)',color='white')
-        ax.plot([],[],label=r'$m_{dark}$=10 GeV, $r_{inv}$=0.3',color='white')
+        ax.plot([],[],label=r'$m_{\mathrm{dark}}=10$ GeV, $r_{\mathrm{inv}}=0.3$',color='white')
 
         ax.fill_between(
             [p.mz for p in points if p.limit.twosigma_success],
@@ -860,11 +860,11 @@ def brazil():
         )
         #ax.text(1.5,0.7,'95% CL upper limits (cut-based)',fontsize=10)
         #ax.text(1.5,0.5, r'$m_{dark}$=10 GeV, $r_{inv}$=0.3',fontsize=10)
-        ax.set_xlabel(r'$m_{Z\prime}$ (GeV)')
+        ax.set_xlabel(r'$m_{\mathrm{Z}^{\prime}}$ [GeV]')
         ax.set_ylim(0.1,50)
         ax.grid(True)
         #ax.set_ylabel(r'$\mu$')
-        ax.set_ylabel(r'$\sigma \times BR$(pb)')
+        ax.set_ylabel(r'$\sigma B$ [pb]')
         ax.set_yscale('log')
         apply_ranges(ax)
         ax.legend(framealpha=0.0)

--- a/run_bias_or_self_study.sh
+++ b/run_bias_or_self_study.sh
@@ -13,6 +13,7 @@
 # ./run_bias_study.sh -d 20240930 -f --sel cutbased --test_type bias --siginj 1.0 --mMed_values "200 300 500"
 
 # Default values
+hists_dir="hists"
 hists_date="20241115"   # Date of the histograms used to make the data cards
 dc_date=$(date +%Y%m%d)     # Today's date for gentoys command
 toys_date=$(date +%Y%m%d)   # Today's date for fittoys command
@@ -37,6 +38,7 @@ while [[ "$#" -gt 0 ]]; do
         --sel) sel="$2"; shift ;;
         --test_type) test_type="$2"; shift ;;
         --dc_date) dc_date="$2"; shift ;;
+        --hists_dir) hists_dir="$2"; shift ;;
         --hists_date) hists_date="$2"; shift ;;
         --siginj) siginj="$2"; shift ;;
         --rmax) rmax="$2"; shift ;;
@@ -82,8 +84,8 @@ if [ "$run_only_fits" == false ] && [ "$skip_dc" == false ]; then
     get_signame
     # Generate datacards for the current mMed value with variable mDark and hists_date
     (set -x; python3 cli_boosted.py gen_datacards \
-      --bkg hists/merged_${hists_date}/bkg_sel-${sel}.json \
-      --sig hists/smooth_${hists_date}/${sig_name}.json)
+      --bkg ${hists_dir}/merged_${hists_date}/bkg_sel-${sel}.json \
+      --sig ${hists_dir}/smooth_${hists_date}/${sig_name}.json)
   done
 fi
 


### PR DESCRIPTION
The hack that I implemented to be able to seed values in background PDF parameters during MultiDimFit caused an issue for the impact evaluation. Therefore, an option is added to run `text2workspace.py` (`--t2w`) upon datacard creation, where the hack can be turned off by passing another option `--X-no-flatParam-prior`. Also a few other minor fixes.

Also, propagate the consistency improvements and new arguments from #17 to the asimov test script.