### PR TITLE
Bug Fix for rate values less than 100

### DIFF
--- a/boosted_fits.py
+++ b/boosted_fits.py
@@ -1527,7 +1527,10 @@ def parse_dc(dc):
     table = [['bin', 'process', 'process', 'rate']]
     for bin in dc.rates:
         for proc in dc.rates[bin]:
-            table.append([bin, proc, proc_nr(proc), int(dc.rates[bin][proc])])
+            rate_value = dc.rates[bin][proc]
+            # make the rate -1 for values < 100 so combine will grab the shape value
+            # rather than a potentially problematic int 
+            table.append([bin, proc, proc_nr(proc), int(rate_value) if rate_value >= 100 else -1])
     txt += '\n' + tabelize(transpose(table))
 
     txt += line


### PR DESCRIPTION
Extract shapes value when integer rate is less than 100. This prevents combine from running into issues during the likelihood fits.