### PR TITLE
Revert "Limiting pool count to match the CPU count"

### DIFF
--- a/cli_boosted.py
+++ b/cli_boosted.py
@@ -531,7 +531,7 @@ def likelihood_scan_mp():
         jobs.append(args[:])
 
     import multiprocessing
-    p = multiprocessing.Pool(os.cpu_count())
+    p = multiprocessing.Pool(16)
     p.map(likelihood_scan, jobs)
     p.close()
     p.join()


### PR DESCRIPTION
This reverts commit 3d8f77ed1ce1183928a9c2bfe30087ed7bf4cadd.

(in order to avoid rebasing the massive "new background estimation" PR #25)